### PR TITLE
Fix pipeline deployment conditions for version tags

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -188,8 +188,8 @@ steps:
   - label: ":package: Prepare Stage Deployment"
     key: prepare-stage
     depends_on: docker-push
-    # Only run stage deployment on main branch
-    if: build.branch == pipeline.default_branch
+    # Only run stage deployment on main branch or version tags
+    if: build.branch == pipeline.default_branch || build.env("BUILDKITE_TAG") =~ /^v[0-9]+\.[0-9]+\.[0-9]+/
     commands:
       - echo "Preparing stage deployment branch..."
       - chmod +x scripts/deploy-to-env.sh
@@ -198,8 +198,8 @@ steps:
   # Manual step to create stage PR
   - block: ":point_right: Create Stage PR"
     key: create-stage-pr
-    # Only run stage deployment on main branch
-    if: build.branch == pipeline.default_branch
+    # Only run stage deployment on main branch or version tags
+    if: build.branch == pipeline.default_branch || build.env("BUILDKITE_TAG") =~ /^v[0-9]+\.[0-9]+\.[0-9]+/
     depends_on: prepare-stage
     prompt: "Stage deployment branch is ready. Create PR?"
     blocked_state: passed
@@ -208,8 +208,8 @@ steps:
   - label: ":rocket: Create Stage PR" 
     key: deploy-stage
     depends_on: create-stage-pr
-    # Only run stage deployment on main branch
-    if: build.branch == pipeline.default_branch
+    # Only run stage deployment on main branch or version tags
+    if: build.branch == pipeline.default_branch || build.env("BUILDKITE_TAG") =~ /^v[0-9]+\.[0-9]+\.[0-9]+/
     commands:
       - echo "Creating stage deployment PR..."
       - chmod +x scripts/deploy-to-env.sh


### PR DESCRIPTION
## Summary
- Fixed stage deployment steps to trigger on version tag builds
- Updated pipeline conditions to include both default branch and version tag builds
- Resolves issue where v1.0.0 tag build didn't trigger stage/prod deployment steps

## Problem
The stage deployment steps (prepare-stage, create-stage-pr, deploy-stage) were only configured to run on the default branch (`master`), but version tag builds don't count as being on the default branch. This prevented the deployment pipeline from triggering for tag builds like `v1.0.0`.

## Solution
Updated the conditional logic in `.buildkite/pipeline.yml` for three deployment steps:
- `prepare-stage` (line 192)
- `create-stage-pr` (line 202) 
- `deploy-stage` (line 212)

Changed from:
```yaml
if: build.branch == pipeline.default_branch
```

To:
```yaml
if: build.branch == pipeline.default_branch || build.env("BUILDKITE_TAG") =~ /^v[0-9]+\.[0-9]+\.[0-9]+/
```

## Test plan
- [ ] Merge this PR
- [ ] Create a new version tag (e.g., v1.0.1)
- [ ] Verify that stage deployment steps trigger on the tag build
- [ ] Verify that production deployment steps become available after stage completion

🤖 Generated with [Claude Code](https://claude.ai/code)